### PR TITLE
chore - uses volta to standardize npm + node

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,5 +23,9 @@
     "tailwindcss": "^3.3.0",
     "eslint": "^8",
     "eslint-config-next": "14.0.4"
+  },
+  "volta": {
+    "npm": "10.2.5",
+    "node": "20.10.0"
   }
 }


### PR DESCRIPTION
Now anyone in this repo who has Volta installed on their device will automatically switch to
npm 10.2.5 and node 20.10.0, but these deps in other repos is not impacted. This makes setting up your
local env to work in this repo a little more
hassle free, and ensures devs are on the same
version of this deps which can reduce local dev
conflicts.

See https://docs.volta.sh/guide/getting-started
for how to install Volta to your device.